### PR TITLE
Import order check with isort, based on 100 characters per line

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+    - name: Import order check with isort, based on 100 characters per line
+      run: |
+          isort -l 100 --check .
     - name: Typecheck with mypy
       run: |
           mypy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,11 @@
 
 import os
 import sys
+
 import sphinx_rtd_theme
+
 sys.path.insert(0, os.path.abspath('../..'))
 import ensightreader
-
 
 # -- Project information -----------------------------------------------------
 

--- a/ensight2obj.py
+++ b/ensight2obj.py
@@ -14,12 +14,14 @@ For commandline usage, run the script with ``--help``.
 
 """
 
+import argparse
 import re
 import sys
 from typing import Optional
-import ensightreader
+
 import numpy as np
-import argparse
+
+import ensightreader
 
 
 def main() -> int:

--- a/ensight2vtk.py
+++ b/ensight2vtk.py
@@ -15,13 +15,14 @@ For commandline usage, run the script with ``--help``.
 
 """
 
+import argparse
 import mmap
+import os.path as op
 import re
 import sys
 from typing import Optional
-from ensightreader import read_case, EnsightCaseFile, ElementType, VariableType
-import argparse
-import os.path as op
+
+from ensightreader import ElementType, EnsightCaseFile, VariableType, read_case
 
 
 def main() -> int:

--- a/ensightreader.py
+++ b/ensightreader.py
@@ -19,15 +19,15 @@
 # THE SOFTWARE.
 
 
-import os
-from enum import Enum
-from dataclasses import dataclass, field
-from typing import List, Dict, Optional, Tuple, Union, Type, TypeVar, BinaryIO, TextIO
-import numpy as np
-import re
-import os.path as op
 import mmap
+import os
+import os.path as op
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import BinaryIO, Dict, List, Optional, TextIO, Tuple, Type, TypeVar, Union
 
+import numpy as np
 
 T = TypeVar('T')
 SeekableBufferedReader = Union[BinaryIO, mmap.mmap]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
 mypy
+isort
 
 -r ./docs/requirements.txt

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -1,11 +1,12 @@
-import numpy as np
-import tempfile
 import os.path as op
+import tempfile
+
+import numpy as np
+
 from ensight2obj import ensight2obj
 from ensight2vtk import ensight2vtk
-from ensightreader import read_case, EnsightGeometryFile, GeometryPart, IdHandling, ElementType, VariableLocation, \
-    VariableType
-
+from ensightreader import (ElementType, EnsightGeometryFile, GeometryPart, IdHandling,
+                           VariableLocation, VariableType, read_case)
 
 ENSIGHT_CASE_PATH = "./data/cavity/cavity.case"
 

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -1,11 +1,12 @@
-import numpy as np
-import tempfile
 import mmap
 import os.path as op
-from ensightreader import read_case, EnsightGeometryFile, GeometryPart, IdHandling, ElementType
+import tempfile
+
+import numpy as np
+
 from ensight2obj import ensight2obj
 from ensight2vtk import ensight2vtk
-
+from ensightreader import ElementType, EnsightGeometryFile, GeometryPart, IdHandling, read_case
 
 ENSIGHT_CASE_PATH = "./data/sphere/sphere.case"
 


### PR DESCRIPTION
In this pull request, I propose to sort import instructions with isort.

One can sort with command

```bash
isort .
```

One can check import with command (command used in CI)

```bash
isort --check .
```


If interested, one can go step further with code formatting based on black